### PR TITLE
[NASA 48] Criar método unlink

### DIFF
--- a/examples/identify.php
+++ b/examples/identify.php
@@ -30,9 +30,27 @@ $dito = new Dito(array(
 //   )
 // ));
 
-$dito->track(array(
-  'facebook_id' => '10202840988483394',
-  'event' => array(
-    'action' => 'acao-teste'
-  )
-));
+// $dito->track(array(
+//   'facebook_id' => '10202840988483394',
+//   'event' => array(
+//     'action' => 'acao-teste'
+//   )
+// ));
+
+// $dito->identify(array(
+//   'id' => 3123123321,
+//   'name' => 'Pedro Paiva',
+//   'email' => 'pedro.paiva@dito.com.br',
+//   'data' => array(
+//     'cargo' => 'Desenvolvedor'
+//   )
+// ));
+
+// $dito->link(array(
+//   'id' => 3123123321,
+//   'accounts' => array(
+//     'portal' => array(
+//       'id' => 10202840988483394,
+//     )
+//   )
+// ));

--- a/examples/identify.php
+++ b/examples/identify.php
@@ -54,3 +54,12 @@ $dito = new Dito(array(
 //     )
 //   )
 // ));
+
+// $dito->unlink(array(
+//   'id' => 3123123321,
+//   'accounts' => array(
+//     'portal' => array(
+//       'id' => 10202840988483394,
+//     )
+//   )
+// ));

--- a/lib/Dito.php
+++ b/lib/Dito.php
@@ -141,7 +141,7 @@ class Dito {
 
     if(!isset($id)){
       return array(
-        'error' => array('message' => 'Missing the user id param. See the available options here: http://developers.dito.com.br/docs/sdks/ruby')
+        'error' => array('message' => 'Missing the user id param. See the available options here: http://developers.dito.com.br/docs/php-sdk')
       );
     }
 
@@ -151,30 +151,54 @@ class Dito {
     return $this->request('post', 'events', '/users/'. $id, $params);
   }
 
+  public function link($options = array()) {
+    $credentials = $this->generateIDAndIDType($options);
+    $id = $credentials['id'];
+    $idType = $credentials['idType'];
+    $networkName = $credentials['networkName'];
+
+    if(!isset($id)){
+      return array(
+        'error' => array('message' => 'Missing the user id param. See the available options here: http://developers.dito.com.br/docs/php-sdk')
+      );
+    }
+
+    $params = array('accounts' => json_encode($options['accounts']));
+    if(isset($idType)) $params['id_type'] = $idType;
+    if(isset($networkName)) $params['network_name'] = $networkName;
+
+    return $this->request('post', 'login', "/users/{$id}/link", $params);
+  }
+
   private
 
   function generateIDAndIDType($options = array()){
     if(isset($options['reference'])){
       $id = $options['reference'];
       $idType = nil;
+      $networkName = nil;
     }
     else if(isset($options['facebook_id'])){
       $id = $options['facebook_id'];
       $idType = 'facebook_id';
+      $networkName = 'fb';
     }
     else if(isset($options['google_plus_id'])){
       $id = $options['google_plus_id'];
       $idType = 'google_plus_id';
+      $networkName = 'pl';
     }
     else if(isset($options['twitter_id'])){
       $id = $options['twitter_id'];
       $idType = 'twitter_id';
+      $networkName = 'tw';
     }
     else if(isset($options['id'])){
       $id = $options['id'];
       $idType = 'id';
+      $networkName = 'pt';
     }
 
-    return array('id' => $id, 'idType' => $idType);
+    return array('id' => $id, 'idType' => $idType, 'networkName' => $networkName);
   }
 }

--- a/lib/Dito.php
+++ b/lib/Dito.php
@@ -151,7 +151,7 @@ class Dito {
     return $this->request('post', 'events', '/users/'. $id, $params);
   }
 
-  public function link($options = array()) {
+  private function buildParamsLinkUnlink($options = array()) {
     $credentials = $this->generateIDAndIDType($options);
     $id = $credentials['id'];
     $idType = $credentials['idType'];
@@ -167,7 +167,19 @@ class Dito {
     if(isset($idType)) $params['id_type'] = $idType;
     if(isset($networkName)) $params['network_name'] = $networkName;
 
+    return [$id, $params];
+  }
+
+  public function link($options = array()) {
+    list($id, $params) = $this->buildParamsLinkUnlink($options);
+
     return $this->request('post', 'login', "/users/{$id}/link", $params);
+  }
+
+  public function unlink($options = array()) {
+    list($id, $params) = $this->buildParamsLinkUnlink($options);
+
+    return $this->request('post', 'login', "/users/{$id}/unlink", $params);
   }
 
   private

--- a/lib/Dito.php
+++ b/lib/Dito.php
@@ -157,12 +157,6 @@ class Dito {
     $idType = $credentials['idType'];
     $networkName = $credentials['networkName'];
 
-    if(!isset($id)){
-      return array(
-        'error' => array('message' => 'Missing the user id param. See the available options here: http://developers.dito.com.br/docs/php-sdk')
-      );
-    }
-
     $params = array('accounts' => json_encode($options['accounts']));
     if(isset($idType)) $params['id_type'] = $idType;
     if(isset($networkName)) $params['network_name'] = $networkName;
@@ -170,13 +164,40 @@ class Dito {
     return [$id, $params];
   }
 
+  private function validationParamsLinkUnlink($options = array()) {
+    $credentials = $this->generateIDAndIDType($options);
+    $id = $credentials['id'];
+
+    if(!isset($id)){
+      return array(
+        'error' => array('message' => 'Missing the user id param. See the available options here: http://developers.dito.com.br/docs/php-sdk')
+      );
+    }
+
+    if(!isset($options['accounts']) || !is_array($options['accounts']) || count($options['accounts']) == 0) {
+      return array(
+        'error' => array('message' => 'Missing the user accounts params. See the available options here: http://developers.dito.com.br/docs/php-sdk')
+      );
+    }
+
+    return false;
+  }
+
   public function link($options = array()) {
+    if($error = $this->validationParamsLinkUnlink($options)) {
+      return $error;
+    }
+
     list($id, $params) = $this->buildParamsLinkUnlink($options);
 
     return $this->request('post', 'login', "/users/{$id}/link", $params);
   }
 
   public function unlink($options = array()) {
+    if($error = $this->validationParamsLinkUnlink($options)) {
+      return $error;
+    }
+    
     list($id, $params) = $this->buildParamsLinkUnlink($options);
 
     return $this->request('post', 'login', "/users/{$id}/unlink", $params);
@@ -187,8 +208,8 @@ class Dito {
   function generateIDAndIDType($options = array()){
     if(isset($options['reference'])){
       $id = $options['reference'];
-      $idType = nil;
-      $networkName = nil;
+      $idType = null;
+      $networkName = null;
     }
     else if(isset($options['facebook_id'])){
       $id = $options['facebook_id'];
@@ -209,6 +230,10 @@ class Dito {
       $id = $options['id'];
       $idType = 'id';
       $networkName = 'pt';
+    } else {
+      $id = null;
+      $idType = null;
+      $networkName = null;
     }
 
     return array('id' => $id, 'idType' => $idType, 'networkName' => $networkName);


### PR DESCRIPTION
# Contexto

Criar método unlink em PHP para acessar a API REST unlink da Dito.

# Como testar

- Ir no arquivo identify.php dentro da pasta examples
- Adicionar um identify seguido de um link e unlink:

```
$dito->identify(array(
  'id' => [REFERENCE],
  'name' => 'Nome',
  'email' => 'email',
  'data' => array(
    'cargo' => 'cargo'
  )
));

$dito->link(array(
  'id' => [REFERENCE],
  'accounts' => array(
    'portal' => array(
      'id' => [ID_DO_USUARIO],
    )
  )
));

$dito->unlink(array(
  'id' => [REFERENCE],
  'accounts' => array(
    'portal' => array(
      'id' => [ID_DO_USUARIO],
    )
  )
));
```
# Impactos no Deploy

- Adicionar um novo release no git e verificar se o composer já fez a integração automática.
- Atualizar a documentação (Adicionar os dois novos métodos e para utilizar a nova versão (release))